### PR TITLE
add support for doctrine second level cache configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,11 @@ Common Setup Options for Doctrine 2.0:
           column1,desc
         {/d:order}
 
+  * `{d:cache}READ_ONLY, NONSTRICT_READ_WRITE, READ_WRITE{/d:cache}` (applied to Table and/or ForeignKey)
+
+    You can specify Doctrine second level caching strategy as a comment on a table or foreign key. They will be generated into the Annotation or YAML.
+    ([Reference](http://doctrine-orm.readthedocs.io/en/latest/reference/second-level-cache.html))
+
 ### Doctrine 2.0 Annotation with ZF2 Input Filter Classes
 
 Doctrine 2.0 Annotation with ZF2 Input Filter Classes formatter directly extend Doctrine 2.0

--- a/lib/MwbExporter/Formatter/Doctrine2/Annotation/Model/Table.php
+++ b/lib/MwbExporter/Formatter/Doctrine2/Annotation/Model/Table.php
@@ -214,6 +214,7 @@ class Table extends BaseTable
         $serializableEntity  = $this->getConfig()->get(Formatter::CFG_GENERATE_ENTITY_SERIALIZATION);
         $extendableEntity    = $this->getConfig()->get(Formatter::CFG_GENERATE_EXTENDABLE_ENTITY);
         $lifecycleCallbacks  = $this->getLifecycleCallbacks();
+        $cacheMode           = $this->getEntityCacheMode();
 
         $extendsClass = $this->getClassToExtend();
         $implementsInterface = $this->getInterfaceToImplement();
@@ -241,6 +242,7 @@ class Table extends BaseTable
             ->write(' *')
             ->writeIf($comment, $comment)
             ->write(' * '.$this->getAnnotation('Entity', array('repositoryClass' => $this->getConfig()->get(Formatter::CFG_AUTOMATIC_REPOSITORY) ? $repositoryNamespace.$this->getModelName().'Repository' : null)))
+            ->writeIf($cacheMode, ' * '.$this->getAnnotation('Cache', array($cacheMode)))
             ->write(' * '.$this->getAnnotation('Table', array('name' => $this->quoteIdentifier($this->getRawTableName()), 'indexes' => $this->getIndexesAnnotation('Index'), 'uniqueConstraints' => $this->getIndexesAnnotation('UniqueConstraint'))))
             ->writeIf($extendableEntity, ' * '.$this->getAnnotation('InheritanceType', array('SINGLE_TABLE')))
             ->writeIf($extendableEntity, ' * '.$this->getAnnotation('DiscriminatorColumn', $this->getInheritanceDiscriminatorColumn()))
@@ -496,6 +498,7 @@ class Table extends BaseTable
             $targetEntityFQCN = $local->getOwningTable()->getModelNameAsFQCN($local->getReferencedTable()->getEntityNamespace());
             $mappedBy = $local->getReferencedTable()->getModelName();
             $related = $local->getForeignM2MRelatedName();
+            $cacheMode = $this->getFormatter()->getCacheOption($local->parseComment('cache'));
 
             $this->getDocument()->addLog(sprintf('  Writing 1 <=> ? relation "%s"', $targetEntity));
 
@@ -512,6 +515,7 @@ class Table extends BaseTable
 
                 $writer
                     ->write('/**')
+                    ->writeIf($cacheMode, ' * '.$this->getAnnotation('Cache', array($cacheMode)))
                     ->write(' * '.$this->getAnnotation('OneToMany', $annotationOptions))
                     ->write(' * '.$this->getJoins($local))
                     ->writeCallback(function(WriterInterface $writer, Table $_this = null) use ($local) {
@@ -530,6 +534,7 @@ class Table extends BaseTable
 
                 $writer
                     ->write('/**')
+                    ->writeIf($cacheMode, ' * '.$this->getAnnotation('Cache', array($cacheMode)))
                     ->write(' * '.$this->getAnnotation('OneToOne', $annotationOptions))
                     ->write(' */')
                     ->write('protected $'.lcfirst($targetEntity).';')
@@ -558,12 +563,14 @@ class Table extends BaseTable
                 'cascade' => $this->getFormatter()->getCascadeOption($foreign->parseComment('cascade')),
                 'fetch' => $this->getFormatter()->getFetchOption($foreign->parseComment('fetch')),
             );
+            $cacheMode = $this->getFormatter()->getCacheOption($foreign->parseComment('cache'));
 
             if ($foreign->isManyToOne()) {
                 $this->getDocument()->addLog('  Relation considered as "N <=> 1"');
 
                 $writer
                     ->write('/**')
+                    ->writeIf($cacheMode, ' * '.$this->getAnnotation('Cache', array($cacheMode)))
                     ->write(' * '.$this->getAnnotation('ManyToOne', $annotationOptions))
                     ->write(' * '.$this->getJoins($foreign, false))
                     ->write(' */')
@@ -580,6 +587,7 @@ class Table extends BaseTable
 
                 $writer
                     ->write('/**')
+                    ->writeIf($cacheMode, ' * '.$this->getAnnotation('Cache', array($cacheMode)))
                     ->write(' * '.$this->getAnnotation('OneToOne', $annotationOptions))
                     ->write(' * '.$this->getJoins($foreign, false))
                     ->write(' */')
@@ -606,6 +614,7 @@ class Table extends BaseTable
                 'cascade' => $this->getFormatter()->getCascadeOption($fk1->parseComment('cascade')),
                 'fetch' => $this->getFormatter()->getFetchOption($fk1->parseComment('fetch')),
             );
+            $cacheMode = $this->getFormatter()->getCacheOption($fk1->parseComment('cache'));
 
             // if this is the owning side, also output the JoinTable Annotation
             // otherwise use "mappedBy" feature
@@ -618,6 +627,7 @@ class Table extends BaseTable
 
                 $writer
                     ->write('/**')
+                    ->writeIf($cacheMode, ' * '.$this->getAnnotation('Cache', array($cacheMode)))
                     ->write(' * '.$this->getAnnotation('ManyToMany', $annotationOptions))
                     ->write(' * '.$this->getAnnotation('JoinTable',
                         array(
@@ -645,6 +655,7 @@ class Table extends BaseTable
                 $annotationOptions['inversedBy'] = null;
                 $writer
                     ->write('/**')
+                    ->writeIf($cacheMode, ' * '.$this->getAnnotation('Cache', array($cacheMode)))
                     ->write(' * '.$this->getAnnotation('ManyToMany', $annotationOptions))
                     ->write(' */')
                 ;

--- a/lib/MwbExporter/Formatter/Doctrine2/Formatter.php
+++ b/lib/MwbExporter/Formatter/Doctrine2/Formatter.php
@@ -153,6 +153,22 @@ abstract class Formatter extends BaseFormatter
     }
 
     /**
+     * get the cache option for an entity or a relation
+     *
+     * @param $cacheValue string cache option as given in comment for table or foreign key
+     * @return string valid cache value or null
+     */
+    public function getCacheOption($cacheValue)
+    {
+        if ($cacheValue) {
+            $cacheValue = strtoupper($cacheValue);
+            if (in_array($cacheValue, array('READ_ONLY', 'NONSTRICT_READ_WRITE', 'READ_WRITE'))) {
+                return $cacheValue;
+            }
+        }
+    }
+
+    /**
      * Parse order option.
      *
      * @param string $sortValue

--- a/lib/MwbExporter/Formatter/Doctrine2/Model/Table.php
+++ b/lib/MwbExporter/Formatter/Doctrine2/Model/Table.php
@@ -53,6 +53,17 @@ class Table extends BaseTable
     }
 
     /**
+     * Get the entity cacheMode.
+     *
+     * @return string
+     */
+    public function getEntityCacheMode()
+    {
+        $cacheMode = strtoupper(trim($this->parseComment('cache')));
+        if (in_array($cacheMode, array('READ_ONLY', 'NONSTRICT_READ_WRITE', 'READ_WRITE'))) return $cacheMode;
+    }
+
+    /**
      * Get namespace of a class.
      *
      * @param string $class The class name

--- a/lib/MwbExporter/Formatter/Doctrine2/Yaml/Model/Table.php
+++ b/lib/MwbExporter/Formatter/Doctrine2/Yaml/Model/Table.php
@@ -74,6 +74,11 @@ class Table extends BaseTable
             'type' => 'entity',
             'table' => $this->getRawTableName(), 
         );
+        // cache Mode
+        if (!is_null($cacheMode = $this->getEntityCacheMode())) {
+            $values['cache'] = array();
+            $values['cache']['usage'] = $cacheMode;
+        }
         if ($this->getConfig()->get(Formatter::CFG_AUTOMATIC_REPOSITORY)) {
             if ($repositoryNamespace = $this->getConfig()->get(Formatter::CFG_REPOSITORY_NAMESPACE)) {
                 $repositoryNamespace .= '\\';
@@ -179,6 +184,9 @@ class Table extends BaseTable
                     'inversedBy'   => lcfirst($this->getRelatedVarName($mappedBy, $related)),
                 ), $this->getJoins($local));
             }
+            if (!is_null($cacheMode = $this->getFormatter()->getCacheOption($local->parseComment('cache')))) {
+              $values[$type][$relationName]['cache']['usage'] = $cacheMode;
+            }
         }
 
         // N <=> ? references
@@ -218,6 +226,9 @@ class Table extends BaseTable
                     'inversedBy'    => $foreign->isUnidirectional() ? null : lcfirst($this->getRelatedVarName($inversedBy, $related)),
                 ), $this->getJoins($foreign, false));
             }
+            if (!is_null($cacheMode = $this->getFormatter()->getCacheOption($foreign->parseComment('cache')))) {
+              $values[$type][$relationName]['cache']['usage'] = $cacheMode;
+            }
         }
 
         return $this;
@@ -255,6 +266,9 @@ class Table extends BaseTable
                         'inverseJoinColumns' => $this->convertJoinColumns($this->getJoins($fk2, false)),
                     ),
                 ));
+                if (!is_null($cacheMode = $this->getFormatter()->getCacheOption($fk1->parseComment('cache')))) {
+                  $values[$type][$relationName]['cache']['usage'] = $cacheMode;
+                }
             } else {
                 if ($fk2->isUnidirectional()) {
                     continue;
@@ -267,6 +281,9 @@ class Table extends BaseTable
                     $values[$type] = array();
                 }
                 $values[$type][$relationName] = $mappings;
+                if (!is_null($cacheMode = $this->getFormatter()->getCacheOption($fk2->parseComment('cache')))) {
+                  $values[$type][$relationName]['cache']['usage'] = $cacheMode;
+                }
             }
         }
 


### PR DESCRIPTION
Hello there,
I've added support for the doctrine second level cache that uses the `@Cache` annotation for entities and relations using a `{d:cache}` model comment either in a table (for caching entities) or in a foreign key (for caching relations).
Feel free to merge it at your wish and convenience.
