### PR TITLE
 add ability to rename related column names with custom labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,23 @@ Common Setup Options for Doctrine 2.0:
 
     You can specify Doctrine second level caching strategy as a comment on a table or foreign key. They will be generated into the Annotation or YAML.
     ([Reference](http://doctrine-orm.readthedocs.io/en/latest/reference/second-level-cache.html))
+    
+    
+  * `{d:relatedNames}RelationTable:NewName{/d:relatedNames}` (applied to Table)
+    
+    Overrides `relatedVarNameFormat`.
+
+    Rename generated related column names when the table names and the `relatedVarNameFormat` pattern are not good enough. The format should be CamelCase singular and should map with the class name that is generated for the related entity.
+    Can be written in the following format:
+
+        RelationTableName:CustomRelationName
+
+    Multiple relations are supported, separated by line break. Example usage:
+        - on the "Products" table, assuming that our schema has multiple tables for "categories" and "images" so we can't use just "Image" and "Category" names for these tables.
+        {d:relationNames}
+        ProductCategory:Category
+        ProductImage:Image
+        {/d:relationNames}
 
 ### Doctrine 2.0 Annotation with ZF2 Input Filter Classes
 

--- a/README.md
+++ b/README.md
@@ -221,11 +221,20 @@ Common Setup Options for Doctrine 2.0:
         RelationTableName:CustomRelationName
 
     Multiple relations are supported, separated by line break. Example usage:
-        - on the "Products" table, assuming that our schema has multiple tables for "categories" and "images" so we can't use just "Image" and "Category" names for these tables.
+        - on a "store_products" table with "store_product_categories" and "store_product_images" related tables:
+        
         {d:relationNames}
-        ProductCategory:Category
-        ProductImage:Image
+        StoreProductCategory:Category
+        StoreProductImage:Image
         {/d:relationNames}
+        
+    It can be used in both parent / child tables. For example, on a "store_product_images" table:
+    
+        {d:relationNames}
+        StoreProduct:Product
+        {/d:relationNames}
+        
+    The generated StoreProduct class will have "category" and "image" properties instead of "storeProductCategory" and "storeProductImage", while the "StoreProductImage" class will have a "product" property instead of "storeProduct".
 
 ### Doctrine 2.0 Annotation with ZF2 Input Filter Classes
 

--- a/lib/MwbExporter/Formatter/Doctrine2/Model/Table.php
+++ b/lib/MwbExporter/Formatter/Doctrine2/Model/Table.php
@@ -128,6 +128,8 @@ class Table extends BaseTable
          * if $name does not match the current ModelName (in case a relation column), check if the table comment includes the `relatedNames` tag
          * and parse that to see if for $name was provided a custom value
          */
+
+        $nameFromCommentTag = '';
         if ($this->getModelName() !== $name) {
 
             $relatedNames = trim($this->parseComment('relatedNames'));
@@ -135,10 +137,13 @@ class Table extends BaseTable
             foreach (explode("\n", $relatedNames) as $relationMap) {
                 list($toChange, $replacement) = explode(':', $relationMap, 2);
                 if ($name === $toChange) {
-                    $name = $replacement;
+                    $nameFromCommentTag = $replacement;
                     break;
                 }
             }
+        }
+        if ($nameFromCommentTag) {
+            $name = $nameFromCommentTag;
         }
         else {
             $name = $related ? strtr($this->getConfig()->get(Formatter::CFG_RELATED_VAR_NAME_FORMAT), array('%name%' => $name, '%related%' => $related)) : $name;

--- a/lib/MwbExporter/Formatter/Doctrine2/Model/Table.php
+++ b/lib/MwbExporter/Formatter/Doctrine2/Model/Table.php
@@ -124,14 +124,17 @@ class Table extends BaseTable
      */
     public function getRelatedVarName($name, $related = null, $plural = false)
     {
+        /**
+         * if $name does not match the current ModelName (in case a relation column), check if the table comment includes the `relatedNames` tag
+         * and parse that to see if for $name was provided a custom value
+         */
         if ($this->getModelName() !== $name) {
 
-            $relationNames = trim($this->parseComment('relatedNames'));
+            $relatedNames = trim($this->parseComment('relatedNames'));
 
-            foreach (explode("\n", $relationNames) as $relationMap) {
+            foreach (explode("\n", $relatedNames) as $relationMap) {
                 list($toChange, $replacement) = explode(':', $relationMap, 2);
                 if ($name === $toChange) {
-                    //var_dump($this->getModelName() . ' / ' . $name . ' / ' . $related . ' / ' . $replacement . ' / ' . $plural);
                     $name = $replacement;
                     break;
                 }

--- a/lib/MwbExporter/Formatter/Doctrine2/Model/Table.php
+++ b/lib/MwbExporter/Formatter/Doctrine2/Model/Table.php
@@ -124,7 +124,22 @@ class Table extends BaseTable
      */
     public function getRelatedVarName($name, $related = null, $plural = false)
     {
-        $name = $related ? strtr($this->getConfig()->get(Formatter::CFG_RELATED_VAR_NAME_FORMAT), array('%name%' => $name, '%related%' => $related)) : $name;
+        if ($this->getModelName() !== $name) {
+
+            $relationNames = trim($this->parseComment('relatedNames'));
+
+            foreach (explode("\n", $relationNames) as $relationMap) {
+                list($toChange, $replacement) = explode(':', $relationMap, 2);
+                if ($name === $toChange) {
+                    //var_dump($this->getModelName() . ' / ' . $name . ' / ' . $related . ' / ' . $replacement . ' / ' . $plural);
+                    $name = $replacement;
+                    break;
+                }
+            }
+        }
+        else {
+            $name = $related ? strtr($this->getConfig()->get(Formatter::CFG_RELATED_VAR_NAME_FORMAT), array('%name%' => $name, '%related%' => $related)) : $name;
+        }
 
         return $plural ? Inflector::pluralize($name) : $name;
     }


### PR DESCRIPTION
Hi,

I came across a situation where I wanted to have cleaner model relations (for json serialization) that don't follow the "relatedVarNameFormat" pattern and can be used with any table names.
For example, having a "products" table and a related "product_images" table, the Product model class was generated with a "productImages" property while I wanted it to be just "images".

I've achieved this by updating the "getRelatedVarName" function to use a new `relatedNames` comment tag on the parent table. Same tag can be added to the child table for changing the parent relation variable name.

I'm not sure if this is the best approach (improvements are welcome), but if you consider it useful and if it doesn't affect anything else then you may want to include it in the main build.

Regards,
Adi