### PR TITLE
update mappedBy annotation to work with tables that reference the cur…

### DIFF
--- a/lib/MwbExporter/Formatter/Doctrine2/Annotation/Model/Table.php
+++ b/lib/MwbExporter/Formatter/Doctrine2/Annotation/Model/Table.php
@@ -507,7 +507,7 @@ class Table extends BaseTable
 
             $annotationOptions = array(
                 'targetEntity' => $targetEntityFQCN,
-                'mappedBy' => lcfirst($this->getRelatedVarName($mappedBy, $related)),
+                'mappedBy' => lcfirst($local->getOwningTable()->getRelatedVarName($mappedBy, $related)),
                 'cascade' => $this->getFormatter()->getCascadeOption($local->parseComment('cascade')),
                 'fetch' => $this->getFormatter()->getFetchOption($local->parseComment('fetch')),
                 'orphanRemoval' => $this->getFormatter()->getBooleanOption($local->parseComment('orphanRemoval')),


### PR DESCRIPTION
After adding the option to add "relatedNames" metadata for renaming relations I came across an issue where the "mappedBy" annotation was not using the altered value. Looks like in this situation the "getRelatedVarName" function was called from the relation table and not from the owning table. 
Before merging please take a look to check if this change could affect something else.
Thanks.