### PR TITLE
Implement boolean column type check

### DIFF
--- a/lib/MwbExporter/Formatter/Doctrine2/Model/Column.php
+++ b/lib/MwbExporter/Formatter/Doctrine2/Model/Column.php
@@ -27,6 +27,7 @@
 namespace MwbExporter\Formatter\Doctrine2\Model;
 
 use MwbExporter\Model\Column as BaseColumn;
+use MwbExporter\Formatter\DatatypeConverterInterface;
 use MwbExporter\Formatter\Doctrine2\Formatter;
 
 class Column extends BaseColumn
@@ -96,5 +97,23 @@ class Column extends BaseColumn
         }
 
         return true;
+    }
+
+    /**
+     * Check If column is boolean.
+     *
+     * @return boolean
+     */
+    public function isBoolean()
+    {
+        $columnType = $this->getColumnType();
+
+        return $this->isUnsigned() &&
+            1 == $this->parameters->get('precision') ? true : false &&
+            (
+                DatatypeConverterInterface::DATATYPE_TINYINT == $columnType() ||
+                DatatypeConverterInterface::USERDATATYPE_BOOL == $columnType() ||
+                DatatypeConverterInterface::USERDATATYPE_BOOLEAN == $columnType()
+            );
     }
 }


### PR DESCRIPTION
Usage of `isBoolean` when it is not defined causes FATAL php error.

Integrating method here's the patch of existing code after running bin script:

```patch
--- a/src/Model/Db/MyTable.php
+++ b/src/Model/Db/MyTable.php
@@ -43,7 +43,7 @@ class MyTable
     /**
      * @ORM\Column(type="boolean", options={"unsigned":true, "default":"1"})
      */
-    protected $is_active = 1;
+    protected $is_active = true;^M
 
     /**
      * @ORM\OneToMany(targetEntity="TargetTable", mappedBy="myTable")
```

Usage: [annotation column](https://github.com/mysql-workbench-schema-exporter/doctrine2-exporter/blob/master/lib/MwbExporter/Formatter/Doctrine2/Annotation/Model/Column.php#L43) and [datatype converter](https://github.com/mysql-workbench-schema-exporter/doctrine2-exporter/blob/master/lib/MwbExporter/Formatter/Doctrine2/DatatypeConverter.php#L141)