### PR TITLE
Improvement: check for new lines

### DIFF
--- a/lib/MwbExporter/Formatter/Doctrine2/Model/Table.php
+++ b/lib/MwbExporter/Formatter/Doctrine2/Model/Table.php
@@ -134,11 +134,13 @@ class Table extends BaseTable
 
             $relatedNames = trim($this->parseComment('relatedNames'));
 
-            foreach (explode("\n", $relatedNames) as $relationMap) {
-                list($toChange, $replacement) = explode(':', $relationMap, 2);
-                if ($name === $toChange) {
-                    $nameFromCommentTag = $replacement;
-                    break;
+            if (false !== strstr($relatedNames, PHP_EOL)) {
+                foreach (explode("\n", $relatedNames) as $relationMap) {
+                    list($toChange, $replacement) = explode(':', $relationMap, 2);
+                    if ($name === $toChange) {
+                        $nameFromCommentTag = $replacement;
+                        break;
+                    }
                 }
             }
         }

--- a/lib/MwbExporter/Formatter/Doctrine2/Model/Table.php
+++ b/lib/MwbExporter/Formatter/Doctrine2/Model/Table.php
@@ -135,7 +135,7 @@ class Table extends BaseTable
             $relatedNames = trim($this->parseComment('relatedNames'));
 
             if (false !== strstr($relatedNames, PHP_EOL)) {
-                foreach (explode("\n", $relatedNames) as $relationMap) {
+                foreach (explode(PHP_EOL, $relatedNames) as $relationMap) {
                     list($toChange, $replacement) = explode(':', $relationMap, 2);
                     if ($name === $toChange) {
                         $nameFromCommentTag = $replacement;


### PR DESCRIPTION
Since each `$relatedNames` value can essentially come back as empty string, it still goes through `foreach` loop and tries to assign `list($toChange, $replacement)`. Eventually string explosion on the right hand side of the equation causes PHP Notice which might be quite disturbing for big projects.

Proposing more secure way of tackling this issue