### PR TITLE
Fix usage of CURRENT_TIMESTAMP as default

### DIFF
--- a/lib/MwbExporter/Formatter/Doctrine2/Annotation/Model/Column.php
+++ b/lib/MwbExporter/Formatter/Doctrine2/Annotation/Model/Column.php
@@ -35,7 +35,7 @@ class Column extends BaseColumn
 {
     private function getStringDefaultValue() {
         $defaultValue = $this->getDefaultValue();
-        if (is_null($defaultValue)) {
+        if (is_null($defaultValue) || 'CURRENT_TIMESTAMP' == $defaultValue) {
             $defaultValue = '';
         } else {
             if ($this->getColumnType() == 'com.mysql.rdbms.mysql.datatype.varchar') {

--- a/lib/MwbExporter/Formatter/Doctrine2/Annotation/Model/Table.php
+++ b/lib/MwbExporter/Formatter/Doctrine2/Annotation/Model/Table.php
@@ -679,6 +679,7 @@ class Table extends BaseTable
             ->write('{')
             ->indent()
                 ->writeCallback(function(WriterInterface $writer, Table $_this = null) {
+                    $_this->writeCurrentTimestampConstructor($writer);
                     $_this->writeRelationsConstructor($writer);
                     $_this->writeManyToManyConstructor($writer);
                 })
@@ -688,6 +689,15 @@ class Table extends BaseTable
         ;
 
         return $this;
+    }
+
+    public function writeCurrentTimestampConstructor(WriterInterface $writer)
+    {
+        foreach ($this->getColumns() as $column) {
+            if ('CURRENT_TIMESTAMP' === $column->getDefaultValue()) {
+                $writer->write('$this->%s = new \DateTime(\'now\');', $column->getColumnName());
+            }
+        }
     }
 
     public function writeRelationsConstructor(WriterInterface $writer)


### PR DESCRIPTION
It is assigned as php constant which is not found, essentially.

```patch
--- a/src/Model/Db/TmpUser.php
+++ b/src/Model/Db/TmpUser.php
@@ -26,10 +26,11 @@ class TmpUser
     /**
      * @ORM\Column(type="datetime", options={"default":"CURRENT_TIMESTAMP"})
      */
-    protected $created = CURRENT_TIMESTAMP;
+    protected $created;^M
 
     public function __construct()
     {
+        $this->created = new \DateTime('now');^M
     }
 
     public function __sleep()
```