### PR TITLE
Add support for json type

### DIFF
--- a/lib/MwbExporter/Formatter/Doctrine2/Annotation/Model/Column.php
+++ b/lib/MwbExporter/Formatter/Doctrine2/Annotation/Model/Column.php
@@ -148,6 +148,10 @@ class Column extends BaseColumn
             $attributes['options'] = array('unsigned' => true);
         }
 
+        if ('json' === $attributes['type']) {
+            $attributes['options']['jsonb'] = true;
+        }
+
         $rawDefaultValue = $this->parameters->get('defaultValue') == 'NULL' ? null : $this->parameters->get('defaultValue');
         if ($rawDefaultValue !== '') {
             $attributes['options']['default'] = $rawDefaultValue === '' ? null : $rawDefaultValue;

--- a/lib/MwbExporter/Formatter/Doctrine2/DatatypeConverter.php
+++ b/lib/MwbExporter/Formatter/Doctrine2/DatatypeConverter.php
@@ -47,6 +47,7 @@ class DatatypeConverter extends BaseDatatypeConverter
             static::DATATYPE_NCHAR              => 'string',
             static::DATATYPE_VARCHAR            => 'string',
             static::DATATYPE_NVARCHAR           => 'string',
+            static::DATATYPE_JSON               => 'json',
             static::DATATYPE_BINARY             => 'blob',
             static::DATATYPE_VARBINARY          => 'blob',
             static::DATATYPE_TINYTEXT           => 'text',


### PR DESCRIPTION
Depends on [PR](https://github.com/mysql-workbench-schema-exporter/mysql-workbench-schema-exporter/pull/166) in mysql-workbench-schema-exporter repo.

Doctrine DBAL already supports [Type of JSON](https://github.com/doctrine/dbal/blob/2.6/lib/Doctrine/DBAL/Types/Type.php#L39).