### PR TITLE
Unassign TINYINT with precision 1 is not boolean.

### DIFF
--- a/lib/MwbExporter/Formatter/Doctrine2/Model/Column.php
+++ b/lib/MwbExporter/Formatter/Doctrine2/Model/Column.php
@@ -109,11 +109,10 @@ class Column extends BaseColumn
         $columnType = $this->getColumnType();
 
         return $this->isUnsigned() &&
-            1 == $this->parameters->get('precision') ? true : false &&
+            (1 == $this->parameters->get('precision')) &&
             (
-                DatatypeConverterInterface::DATATYPE_TINYINT == $columnType() ||
-                DatatypeConverterInterface::USERDATATYPE_BOOL == $columnType() ||
-                DatatypeConverterInterface::USERDATATYPE_BOOLEAN == $columnType()
+                DatatypeConverterInterface::USERDATATYPE_BOOL == $columnType ||
+                DatatypeConverterInterface::USERDATATYPE_BOOLEAN == $columnType
             );
     }
 }


### PR DESCRIPTION
1. Unassign TINYINT with precision value "1" can be also int with value range "0-9".
1. Secound thing is that ```DatatypeConverterInterface::(...) == $columnType()``` generates error ```Fatal error: Uncaught Error: Call to undefined function com.mysql.rdbms.mysql.datatype.tinyint() in /(...)/lib/MwbExporter/Formatter/Doctrine2/Model/Column.php:115``` so I assume that this was never checked.