### PR TITLE
When precision is 1 and column is unsigned, there will be always boolean.

### DIFF
--- a/lib/MwbExporter/Formatter/Doctrine2/Model/Column.php
+++ b/lib/MwbExporter/Formatter/Doctrine2/Model/Column.php
@@ -109,11 +109,11 @@ class Column extends BaseColumn
         $columnType = $this->getColumnType();
 
         return $this->isUnsigned() &&
-            1 == $this->parameters->get('precision') ? true : false &&
+            (1 == $this->parameters->get('precision')) &&
             (
-                DatatypeConverterInterface::DATATYPE_TINYINT == $columnType() ||
-                DatatypeConverterInterface::USERDATATYPE_BOOL == $columnType() ||
-                DatatypeConverterInterface::USERDATATYPE_BOOLEAN == $columnType()
+                DatatypeConverterInterface::DATATYPE_TINYINT == $columnType ||
+                DatatypeConverterInterface::USERDATATYPE_BOOL == $columnType ||
+                DatatypeConverterInterface::USERDATATYPE_BOOLEAN == $columnType
             );
     }
 }


### PR DESCRIPTION
1. ```UNSIGNED SMALLINT(1)``` is always ```boolean```.
2. ```DatatypeConverterInterface::(...) == $columnType()``` generates error Fatal error: Uncaught Error: Call to undefined function com.mysql.rdbms.mysql.datatype.tinyint() in /(...)/lib/MwbExporter/Formatter/Doctrine2/Model/Column.php:115 so I assume that this was never checked.

