### PR TITLE
PHP7 typehints

### DIFF
--- a/lib/MwbExporter/Formatter/Doctrine2/Annotation/Formatter.php
+++ b/lib/MwbExporter/Formatter/Doctrine2/Annotation/Formatter.php
@@ -35,7 +35,9 @@ class Formatter extends BaseFormatter
 {
     const CFG_ANNOTATION_PREFIX                     = 'useAnnotationPrefix';
     const CFG_EXTENDS_CLASS                         = 'extendsClass';
-    const CFG_PROPERTY_TYPEHINT                     = 'propertyTypehint';
+    const CFG_PHP7_ARG_TYPEHINTS                    = 'php7ArgTypehints';
+    const CFG_PHP7_RETURN_TYPEHINTS                 = 'php7ReturnTypehints';
+    const CFG_PHP7_SKIPPED_COLUMNS_TYPEHINTS        = 'php7SkippedColumnsTypehints';
     const CFG_SKIP_GETTER_SETTER                    = 'skipGetterAndSetter';
     const CFG_GENERATE_ENTITY_SERIALIZATION         = 'generateEntitySerialization';
     const CFG_GENERATE_EXTENDABLE_ENTITY            = 'generateExtendableEntity';
@@ -61,7 +63,9 @@ class Formatter extends BaseFormatter
             static::CFG_USE_BEHAVIORAL_EXTENSIONS           => false,
             static::CFG_QUOTE_IDENTIFIER_STRATEGY           => static::QUOTE_IDENTIFIER_AUTO,
             static::CFG_EXTENDS_CLASS                       => '',
-            static::CFG_PROPERTY_TYPEHINT                   => false,
+            static::CFG_PHP7_ARG_TYPEHINTS                  => false,
+            static::CFG_PHP7_RETURN_TYPEHINTS               => false,
+            static::CFG_PHP7_SKIPPED_COLUMNS_TYPEHINTS      => [],
         ));
         $this->addValidators(array(
             static::CFG_QUOTE_IDENTIFIER_STRATEGY           => new ChoiceValidator(array(

--- a/lib/MwbExporter/Formatter/Doctrine2/Annotation/Model/Column.php
+++ b/lib/MwbExporter/Formatter/Doctrine2/Annotation/Model/Column.php
@@ -39,13 +39,14 @@ class Column extends BaseColumn
             $defaultValue = '';
         } else {
             if ($this->getColumnType() == 'com.mysql.rdbms.mysql.datatype.varchar') {
-                $defaultValue = " = '$defaultValue'";
+                $defaultValue = " = $defaultValue";
             } elseif ($this->isBoolean()) {
                 $defaultValue = " = ".($defaultValue == 0 ? 'false' : 'true');
             } else {
                 $defaultValue = " = $defaultValue";
             }
         }
+
         return $defaultValue;
     }
 
@@ -100,7 +101,7 @@ class Column extends BaseColumn
                 'set_return' => $this->returnTypehint(null, false),
 
                 'get_phpdoc' => $this->typehint($nativeType, !$this->isNotNull()),
-                'get_return' => $this->returnTypehint($nativeType, !$this->isNotNull()),
+                'get_return' => $this->returnTypehint($nativeType, null === $this->getDefaultValue() ? true : !$this->isNotNull()),
             ];
 
             $writer

--- a/lib/MwbExporter/Formatter/Doctrine2/Annotation/Model/Column.php
+++ b/lib/MwbExporter/Formatter/Doctrine2/Annotation/Model/Column.php
@@ -100,8 +100,7 @@ class Column extends BaseColumn
                 'set_return' => $this->returnTypehint(null, false),
 
                 'get_phpdoc' => $this->typehint($nativeType, !$this->isNotNull()),
-//                'get_return' => $this->returnTypehint($nativeType, !$this->isNotNull()),
-                'get_return' => $this->returnTypehint($nativeType, null === $this->getDefaultValue()),
+                'get_return' => $this->returnTypehint($nativeType, !$this->isNotNull()),
             ];
 
             $writer

--- a/lib/MwbExporter/Formatter/Doctrine2/Annotation/Model/Table.php
+++ b/lib/MwbExporter/Formatter/Doctrine2/Annotation/Model/Table.php
@@ -263,7 +263,7 @@ class Table extends BaseTable
             ->writeIf($comment, $comment)
             ->writeIf($extendableEntity, ' * @ORM\MappedSuperclass')
             ->writeIf($hasDeletableBehaviour,
-                    ' * @Gedmo\SoftDeleteable(fieldName="deleted_at", timeAware=false)')
+                    ' * @Gedmo\SoftDeleteable(fieldName="deleted_at", timeAware=false, hardDelete=false)')
             ->writeIf(!$extendableEntity,
                     ' * '.$this->getAnnotation('Entity', array('repositoryClass' => $this->getConfig()->get(Formatter::CFG_AUTOMATIC_REPOSITORY) ? $repositoryNamespace.$this->getModelName().'Repository' : null)))
             ->writeIf($cacheMode, ' * '.$this->getAnnotation('Cache', array($cacheMode)))

--- a/lib/MwbExporter/Formatter/Doctrine2/DatatypeConverter.php
+++ b/lib/MwbExporter/Formatter/Doctrine2/DatatypeConverter.php
@@ -118,14 +118,11 @@ class DatatypeConverter extends BaseDatatypeConverter
                 break;
 
             case 'smallint':
-            case 'bigint':
                 $type = 'integer';
                 break;
 
             case 'decimal':
-                $type = 'float';
-                break;
-
+            case 'bigint':
             case 'text':
             case 'blob':
                 $type = 'string';


### PR DESCRIPTION
The purpose of this PR is to provide a way to add PHP7 type hints to generated entities.
3 new options allow to control how typehints are generated:
- php7ArgTypehints: enable/disable PHP7 typehints for setter/adder/remover arguments
- php7ReturnTypehints: enable/disable PHP7 typehints for method return values
- php7SkippedColumnsTypehints: allow to skip specific columns when generating typehints (to solve compatibility troubles with entities implementing external interfaces that already set typehints)

Example config file:
```yaml
{
    "export": "doctrine2-annotation",
    "zip": false,
    "dir": "output",
    "params": {
        "addGeneratorInfoAsComment": false,
        "backupExistingFile": false,
        "skipPluralNameChecking": true,
        "enhanceManyToManyDetection": true,
        "bundleNamespace": "App",
        "entityNamespace": "Entity",
        "repositoryNamespace": "App\\Repository",
        "useAnnotationPrefix": "ORM\\",
        "useAutomaticRepository": true,
        "indentation": 4,
        "filename": "%entity%.%extension%",
        "quoteIdentifier": false,
        "useBehavioralExtensions": true,
        "logFile": "output.log",
        "generateExtendableEntity": true,
        "extendableEntityHasDiscriminator": false,
        "stripMultipleUnderscores": true,
        "php7ArgTypehints": true,
        "php7ReturnTypehints": true,
        "php7SkippedColumnsTypehints": [
            "contact.phone_number",
            "contact.mobile_phone_number"
        ]
    }
}
```