### PR TITLE
change from inversedBy to mappedBy

### DIFF
--- a/lib/MwbExporter/Formatter/Doctrine2/Yaml/Model/Table.php
+++ b/lib/MwbExporter/Formatter/Doctrine2/Yaml/Model/Table.php
@@ -182,7 +182,7 @@ class Table extends BaseTable
                 }
                 $values[$type][$relationName] = array_merge(array(
                     'targetEntity' => $targetEntity,
-                    'inversedBy'   => lcfirst($this->getRelatedVarName($mappedBy, $related)),
+                    'mappedBy'   => lcfirst($this->getRelatedVarName($mappedBy, $related)),
                 ), $this->getJoins($local));
             }
             if (!is_null($cacheMode = $this->getFormatter()->getCacheOption($local->parseComment('cache')))) {


### PR DESCRIPTION
One 2 One Bidirectional Association Mapping should have one side `mappedBy` and another `inversedBy`: https://www.doctrine-project.org/projects/doctrine-orm/en/2.6/reference/association-mapping.html#one-to-one-bidirectional

> Here we see the mappedBy and inversedBy annotations for the first time. They are used to tell Doctrine which property on the other side refers to the object.

Probably an error when copy-paste the code.