### PR TITLE
relationNames and relatedNames tags update

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,32 @@ Common Setup Options for Doctrine 2.0:
         {/d:relatedNames}
         
     The generated StoreProduct class will have "category" and "image" properties instead of "storeProductCategory" and "storeProductImage", while the "StoreProductImage" class will have a "product" property instead of "storeProduct".
+    
+    This tag can also be used on Many to Many tables (in comments as well), to change the relation names used in each of the 2 tables.
+    For example, on a store_product_category m2m table, having two foreign keys only (store_product_id and store_category_id), we could have the following:
+    
+        {d:relatedNames}
+        StoreProduct:Product
+        StoreCategory:Category
+        {/d:relatedNames}
+        
+    This will generate `products` and `categories` collection properties (along with methods for adding and removing items) on each of the two entities. 
+    
+   * `{d:relationNames}oneToManyName:manyToOneName{/d:relationNames}` (applied to ForeignKey)
+  
+     Overrides `relatedVarNameFormat` and the `relatedNames` tag from above. Useful when one table references another table multiple times, with multiple foreign keys.
+     
+     The two names should be the desired field names that this relation would be represented by in the two model classes.
+     
+     For example, considering a Ticket class and a User class. A ticket could reference the User class with two foreign keys: owner_id and assigned_user_id.
+     
+     On the Tickets table we could use 
+        - `{d:relationNames}Owner:OwnedTickets{/d:relationNames}` on the owner_id foreign key
+        and
+        - `{d:relationNames}AssignedUser:AssignedTickets{/d:relationNames}` on the assigned_user_id foreign key
+     to override the field names, so a Ticket will have `owner` and `assignedUser` fields, while User will have `ownedTickets` and `assignedTickets`.
+     
+     Ideally these names would be CamelCase. The oneToMany would be singular and the ManyToOne would be plural.
 
 ### Doctrine 2.0 Annotation with ZF2 Input Filter Classes
 

--- a/lib/Annotation/Formatter.php
+++ b/lib/Annotation/Formatter.php
@@ -48,6 +48,7 @@ class Formatter extends BaseFormatter
     const CFG_USE_BEHAVIORAL_EXTENSIONS             = 'useBehavioralExtensions';
 
     const NAMING_AS_IS                              = 'as-is';
+    const NAMING_AS_IS_LCFIRST                      = 'as-is-lcfirst';
     const NAMING_CAMEL_CASE                         = 'camel-case';
     const NAMING_PASCAL_CASE                        = 'pascal-case';
 
@@ -78,6 +79,7 @@ class Formatter extends BaseFormatter
         $this->addValidators(array(
             static::CFG_NAMING_STRATEGY                     => new ChoiceValidator(array(
                 static::NAMING_AS_IS,
+                static::NAMING_AS_IS_LCFIRST,
                 static::NAMING_CAMEL_CASE,
                 static::NAMING_PASCAL_CASE,
             )),

--- a/lib/Annotation/Model/Table.php
+++ b/lib/Annotation/Model/Table.php
@@ -1208,6 +1208,9 @@ class Table extends BaseTable
         switch ($strategy) {
             case Formatter::NAMING_AS_IS:
                 break;
+            case Formatter::NAMING_AS_IS_LCFIRST:
+                $name = lcfirst($name);
+                break;
             case Formatter::NAMING_CAMEL_CASE:
                 $name = lcfirst($this->beautify($name));
                 break;

--- a/lib/Yaml/Model/Table.php
+++ b/lib/Yaml/Model/Table.php
@@ -160,13 +160,13 @@ class Table extends BaseTable
                 $this->getDocument()->addLog('  Relation considered as "1 <=> N"');
 
                 $type = 'oneToMany';
-                $relationName = lcfirst($this->getRelatedVarName($targetEntity, $related, true));
+                $relationName = lcfirst($this->getRelatedVarName($targetEntity, $related, true, $local));
                 if (!isset($values[$type])) {
                     $values[$type] = array();
                 }
                 $values[$type][$relationName] = array_merge(array(
                     'targetEntity'  => $targetEntity,
-                    'mappedBy'      => lcfirst($this->getRelatedVarName($mappedBy, $related)),
+                    'mappedBy'      => lcfirst($this->getRelatedVarName($mappedBy, $related, false, $local)),
                     'cascade'       => $this->getFormatter()->getCascadeOption($local->parseComment('cascade')),
                     'fetch'         => $this->getFormatter()->getFetchOption($local->parseComment('fetch')),
                     'orphanRemoval' => $this->getFormatter()->getBooleanOption($local->parseComment('orphanRemoval')),
@@ -181,7 +181,7 @@ class Table extends BaseTable
                 }
                 $values[$type][$relationName] = array_merge(array(
                     'targetEntity' => $targetEntity,
-                    'mappedBy'   => lcfirst($this->getRelatedVarName($mappedBy, $related)),
+                    'mappedBy'   => lcfirst($this->getRelatedVarName($mappedBy, $related, false, $local)),
                 ), $this->getJoins($local));
             }
             if (!is_null($cacheMode = $this->getFormatter()->getCacheOption($local->parseComment('cache')))) {
@@ -205,13 +205,13 @@ class Table extends BaseTable
                 $this->getDocument()->addLog('  Relation considered as "N <=> 1"');
 
                 $type = 'manyToOne';
-                $relationName = lcfirst($this->getRelatedVarName($targetEntity, $related));
+                $relationName = lcfirst($this->getRelatedVarName($targetEntity, $related, false, $foreign));
                 if (!isset($values[$type])) {
                     $values[$type] = array();
                 }
                 $values[$type][$relationName] = array_merge(array(
                     'targetEntity'  => $targetEntityFQCN,
-                    'inversedBy'    => lcfirst($this->getRelatedVarName($inversedBy, $related, true)),
+                    'inversedBy'    => lcfirst($this->getRelatedVarName($inversedBy, $related, true, $foreign)),
                 ), $this->getJoins($foreign, false));
             } else {
                 $this->getDocument()->addLog('  Relation considered as "1 <=> 1"');
@@ -223,7 +223,7 @@ class Table extends BaseTable
                 }
                 $values[$type][$relationName] = array_merge(array(
                     'targetEntity'  => $targetEntityFQCN,
-                    'inversedBy'    => $foreign->isUnidirectional() ? null : lcfirst($this->getRelatedVarName($inversedBy, $related)),
+                    'inversedBy'    => $foreign->isUnidirectional() ? null : lcfirst($this->getRelatedVarName($inversedBy, $related, false, $foreign)),
                 ), $this->getJoins($foreign, false));
             }
             if (!is_null($cacheMode = $this->getFormatter()->getCacheOption($foreign->parseComment('cache')))) {


### PR DESCRIPTION
This pull request fixes the conflicts from a previously closed pull request (https://github.com/mysql-workbench-schema-exporter/doctrine2-exporter/pull/30) and extends the `relatedNames` tag functionality to M2M relations.

@DamienHarper and @tohenk please take a look and let me know if you think these changes have any ripple effects and affect in any way the updates that have been made in the meantime.

What's your method to test the library and make sure results are consistent after an update?